### PR TITLE
Compatible with multiple versions of Mocha

### DIFF
--- a/lib/adapters/mocha.rb
+++ b/lib/adapters/mocha.rb
@@ -1,6 +1,17 @@
 require 'rubygems'
-require 'mocha/object'
-require 'mocha/api'
+
+begin
+  require 'mocha/api'
+
+  begin
+    require 'mocha/object'
+  rescue LoadError
+    # Mocha >= 0.13.0 no longer contains this file nor needs it to be loaded.
+  end
+rescue LoadError
+  require 'mocha/standalone'
+  require 'mocha/object'
+end
 
 module MultiMock
   module Adapters


### PR DESCRIPTION
Fair warning, I haven't seen this in action with anything less than 1.5 because I can't get my app to even load lower versions of Mocha, but this is what the folks at RSpec Core do and it works for them. Hopefully someone else can give it a go before merging?