### PR TITLE
Update to fix global methods in mocha

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,32 +7,34 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    mocha (0.9.12)
-    rake (0.9.2.2)
+    diff-lcs (1.4.4)
+    metaclass (0.0.4)
+    mocha (1.7.0)
+      metaclass (~> 0.0.1)
+    rake (13.0.6)
     rr (1.1.2)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.3)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
-  mocha (~> 0.9.8)
+  mocha (~> 1.7.0)
   rake
   rr (~> 1.1.2)
   rspec-multi-mock!
 
 BUNDLED WITH
-   1.16.1
+   2.2.28

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rspec-multi-mock (0.3.1)
-      rspec (>= 3.7.0)
+      rspec-core (>= 3.7.0)
 
 GEM
   remote: http://rubygems.org/
@@ -34,6 +34,7 @@ DEPENDENCIES
   mocha (~> 1.7.0)
   rake
   rr (~> 1.1.2)
+  rspec (>= 3.7.0)
   rspec-multi-mock!
 
 BUNDLED WITH

--- a/lib/adapters/mocha.rb
+++ b/lib/adapters/mocha.rb
@@ -16,7 +16,7 @@ end
 module MultiMock
   module Adapters
     class Mocha
-      include ::Mocha::API
+      include ::Mocha::Hooks
 
       alias :setup_mocks_for_rspec :mocha_setup
       alias :verify_mocks_for_rspec :mocha_verify
@@ -24,3 +24,5 @@ module MultiMock
     end
   end
 end
+
+MultiMock::Adapter.send(:include, ::Mocha::API)

--- a/rspec-multi-mock.gemspec
+++ b/rspec-multi-mock.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_runtime_dependency("rspec", ">= 3.7.0")
   s.add_development_dependency("rake")
-  s.add_development_dependency("mocha", "~> 0.9.8")
+  s.add_development_dependency("mocha", "~> 1.7.0")
   s.add_development_dependency("rr", "~> 1.1.2")
 end

--- a/rspec-multi-mock.gemspec
+++ b/rspec-multi-mock.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency("rspec", ">= 3.7.0")
+  s.add_runtime_dependency("rspec-core", ">= 3.7.0")
+  s.add_development_dependency("rspec", ">= 3.7.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("mocha", "~> 1.7.0")
   s.add_development_dependency("rr", "~> 1.1.2")

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -26,6 +26,13 @@ describe MultiMock::Adapter do
     it "should clear the stubs created in previous specs" do
       expect { Object.stubbed_method }.to raise_error(NoMethodError)
     end
+
+    it "should allow using mocks" do
+      test_mock = mock
+      test_mock.expects(:hello).returns("Hello Mocha")
+
+      expect(test_mock.hello).to eq "Hello Mocha"
+    end
   end
 
   context "with rr" do


### PR DESCRIPTION
I get that this is a super old library and you have long moved on from it, but I thought I'd make this PR fixing Mocha as I am currently going through this migration process from Mocha to rspec-mocks.

Without including `Mocha::API` you can't use `mock` in your specs.